### PR TITLE
Minor change :)

### DIFF
--- a/yougo.csv
+++ b/yougo.csv
@@ -13,7 +13,8 @@
 提出,ていしゅつ,submission
 英小文字,えいこもじ,english lower case letters
 からなる,からなる,consists of
-正整数,せいせいすう,positive integer
+正の整数,せいのせいすう,positive integer
+負の整数,ふのせいすう,negative integer
 幅,はば,width
 高さ,たかさ,height
 奥行き,おくゆき,depth
@@ -45,7 +46,7 @@
 種類,しゅるい,counter for kinds;category;kind
 形式,けいしき,form;format
 標準入力,ひょうじゅんにゅうりょく,standard input
-得る,える,to obtain
+得る,える,to obtain;to win;to acquire
 合計,ごうけい,total sum
 異なる,ことなる,to differ
 桁,けた,digit;magnitude
@@ -126,7 +127,6 @@
 繰り返し,くりかえし,repetition
 行動,こうどう,action
 活動,かつどう,activity;action
-得る,うる,to obtain;to win; to acquire
 最大値,さいだいち,maximum value
 価値,かち,value;worth
 容量,ようりょう,capacity


### PR DESCRIPTION
I made small changes!

得る can be read as うる when the word is ○○得る, for example あり得る (ありうる),
but when you use 得る in the meaning of "to obtain", then it's more natural to read える :D
